### PR TITLE
perf(venues): prioritize visible images + responsive srcset + preload…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "exam-holidaze",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.85.6",
         "axios": "^1.11.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -1561,6 +1562,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.6.tgz",
+      "integrity": "sha512-hCj0TktzdCv2bCepIdfwqVwUVWb+GSHm1Jnn8w+40lfhQ3m7lCO7ADRUJy+2unxQ/nzjh2ipC6ye69NDW3l73g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.6.tgz",
+      "integrity": "sha512-VUAag4ERjh+qlmg0wNivQIVCZUrYndqYu3/wPCVZd4r0E+1IqotbeyGTc+ICroL/PqbpSaGZg02zSWYfcvxbdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ci": "biome ci ."
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.85.6",
     "axios": "^1.11.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/api/venues.js
+++ b/src/api/venues.js
@@ -1,8 +1,10 @@
 // src/api/venues.js
 import { httpGet, httpPost, httpPut, httpDelete } from "./http.js";
 
-// List venues (fast: no _bookings; optionally include owner for cards)
-export function listVenues({ page = 1, limit = 25, q, sort, order, withOwner = false } = {}, auth) {
+export function listVenues(
+  { page = 1, limit = 25, q, sort, order, withOwner = false, signal } = {},
+  auth,
+) {
   const params = {
     page,
     limit,
@@ -11,7 +13,7 @@ export function listVenues({ page = 1, limit = 25, q, sort, order, withOwner = f
     sortOrder: order,
     _owner: withOwner || undefined,
   };
-  return httpGet("/holidaze/venues", { params, ...auth });
+  return httpGet("/holidaze/venues", { params, signal, ...auth });
 }
 
 // Single venue — ALWAYS include bookings + owner on details page

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,26 @@
+// src/main.jsx
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
+  // StrictMode optional; you can re-enable later if you like
+  <QueryClientProvider client={queryClient}>
     <AuthProvider>
       <App />
     </AuthProvider>
-  </React.StrictMode>,
+  </QueryClientProvider>,
 );


### PR DESCRIPTION
… top results

- Make first 6 result images eager with high fetchpriority; others lazy
- Add decoding="async" and width/height to avoid layout shift
- Add srcSet/sizes for responsive loading (mobile-friendly bandwidth)
- Preload first 3 images of current page via useEffect
- Keep client-side global sort + top/bottom pagination intact